### PR TITLE
Iteration 3 UDP Communication Including RPC

### DIFF
--- a/src/common/messages/CommunicationFailureMessage.java
+++ b/src/common/messages/CommunicationFailureMessage.java
@@ -1,0 +1,17 @@
+package common.messages;
+
+/**
+ * The class respresents messages that did not send or could not be received
+ * @author delightoluwayemi
+ *
+ */
+public class CommunicationFailureMessage extends Message{
+
+	/**
+	 * A CommunicationFailureMessage constructor.
+	 */
+	public CommunicationFailureMessage() {
+		super(MessageType.COMMUNICATION_FAILURE);
+	}
+
+}

--- a/src/common/messages/Message.java
+++ b/src/common/messages/Message.java
@@ -3,13 +3,15 @@
  */
 package common.messages;
 
+import java.io.Serializable;
+
 /**
  * This class represents a message entity
  *
  * @author paulokenne, ryanfife
  *
  */
-public class Message {
+public class Message implements Serializable {
 
 	/**
 	 * The message type.

--- a/src/common/messages/MessageType.java
+++ b/src/common/messages/MessageType.java
@@ -58,5 +58,10 @@ public enum MessageType {
 	/**
 	 * A request for testing purposes.
 	 */
-	TEST_REQUEST
+	TEST_REQUEST,
+	
+	/**
+	 * A message that indicates that the intended message did not send or could not be received.
+	 */
+	COMMUNICATION_FAILURE
 }

--- a/src/common/remote_procedure/SubsystemCommunicationConfiguarations.java
+++ b/src/common/remote_procedure/SubsystemCommunicationConfiguarations.java
@@ -26,7 +26,7 @@ public final class SubsystemCommunicationConfiguarations {
 	private static final int SCHEDULER_TO_ELEVATOR_SEND_RECEIVE_PORT = 11001;
 
 	/**
-	 * The scheduler port mapping that provide the scheduler port for a given
+	 * The scheduler port mapping that provides the appropriate port for a given
 	 * subsystem.
 	 */
 	public static final Map<SubsystemComponentType, Integer> SCHEDULER_PORT_MAPPING = Map.ofEntries(
@@ -44,8 +44,8 @@ public final class SubsystemCommunicationConfiguarations {
 	private static final int ELEVATOR_TO_SCHEDULER_SEND_RECEIVE_PORT = 12001;
 
 	/**
-	 * The scheduler port mapping that provide the elevator-subsystem port for a
-	 * given subsystem.
+	 * The elevator port mapping that provides the appropriate port for a given
+	 * subsystem.
 	 */
 	public static final Map<SubsystemComponentType, Integer> ELEVATOR_PORT_MAPPING = Map.ofEntries(
 			Map.entry(SubsystemComponentType.SCHEDULER, ELEVATOR_TO_SCHEDULER_SEND_RECEIVE_PORT),
@@ -62,7 +62,7 @@ public final class SubsystemCommunicationConfiguarations {
 	private static final int FlOOR_TO_SCHEDULER_SEND_RECEIVE_PORT = 13001;
 
 	/**
-	 * The scheduler port mapping that provide the floor-subsystem port for a given
+	 * The floor port mapping that provides the appropriate port for a given
 	 * subsystem.
 	 */
 	public static final Map<SubsystemComponentType, Integer> FLOOR_PORT_MAPPING = Map.ofEntries(

--- a/src/common/remote_procedure/SubsystemCommunicationConfiguarations.java
+++ b/src/common/remote_procedure/SubsystemCommunicationConfiguarations.java
@@ -1,0 +1,127 @@
+/**
+ *
+ */
+package common.remote_procedure;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Map;
+
+/**
+ * This class provides the configuration values for each subystem
+ *
+ * @author paulokenne
+ *
+ */
+public final class SubsystemCommunicationConfiguarations {
+
+	/**
+	 * The scheduler send/receive port for the floor subsystem
+	 */
+	private static final int SCHEDULER_TO_FLOOR_SEND_RECEIVE_PORT = 11000;
+
+	/**
+	 * The scheduler send/receive port for the elevator subsystem
+	 */
+	private static final int SCHEDULER_TO_ELEVATOR_SEND_RECEIVE_PORT = 11001;
+
+	/**
+	 * The scheduler port mapping that provide the scheduler port for a given
+	 * subsystem.
+	 */
+	public static final Map<SubsystemComponentType, Integer> SCHEDULER_PORT_MAPPING = Map.ofEntries(
+			Map.entry(SubsystemComponentType.ELEVATOR_SUBSYSTEM, SCHEDULER_TO_ELEVATOR_SEND_RECEIVE_PORT),
+			Map.entry(SubsystemComponentType.FLOOR_SUBSYSTEM, SCHEDULER_TO_FLOOR_SEND_RECEIVE_PORT));
+
+	/**
+	 * The elevator subsystem send/receive port for the floor subsystem
+	 */
+	private static final int ELEVATOR_TO_FLOOR_SEND_RECEIVE_PORT = 12000;
+
+	/**
+	 * The elevator subsystem send/receive port for the scheduler
+	 */
+	private static final int ELEVATOR_TO_SCHEDULER_SEND_RECEIVE_PORT = 12001;
+
+	/**
+	 * The scheduler port mapping that provide the elevator-subsystem port for a
+	 * given subsystem.
+	 */
+	public static final Map<SubsystemComponentType, Integer> ELEVATOR_PORT_MAPPING = Map.ofEntries(
+			Map.entry(SubsystemComponentType.SCHEDULER, ELEVATOR_TO_SCHEDULER_SEND_RECEIVE_PORT),
+			Map.entry(SubsystemComponentType.FLOOR_SUBSYSTEM, ELEVATOR_TO_FLOOR_SEND_RECEIVE_PORT));
+
+	/**
+	 * The floor subsystem send/receive port for the elevator subsystem
+	 */
+	private static final int FlOOR_TO_ELEVATOR_SEND_RECEIVE_PORT = 13001;
+
+	/**
+	 * The floor subsystem send/receive port for the scheduler
+	 */
+	private static final int FlOOR_TO_SCHEDULER_SEND_RECEIVE_PORT = 13001;
+
+	/**
+	 * The scheduler port mapping that provide the floor-subsystem port for a given
+	 * subsystem.
+	 */
+	public static final Map<SubsystemComponentType, Integer> FLOOR_PORT_MAPPING = Map.ofEntries(
+			Map.entry(SubsystemComponentType.SCHEDULER, FlOOR_TO_SCHEDULER_SEND_RECEIVE_PORT),
+			Map.entry(SubsystemComponentType.ELEVATOR_SUBSYSTEM, FlOOR_TO_ELEVATOR_SEND_RECEIVE_PORT));
+
+	/**
+	 * The ip addresses of the scheduler,floor, and elevator
+	 */
+	public static String SCHEDULER_IP_ADDRESS, FLOOR_IP_ADDRESS, ELEVATOR_IP_ADDRESS;
+
+	static {
+		try {
+			SCHEDULER_IP_ADDRESS = InetAddress.getLocalHost().getHostAddress();
+			FLOOR_IP_ADDRESS = InetAddress.getLocalHost().getHostAddress();
+			ELEVATOR_IP_ADDRESS = InetAddress.getLocalHost().getHostAddress();
+		} catch (UnknownHostException e) {
+			System.out.println(e);
+			System.exit(1);
+		}
+	}
+
+	/**
+	 * A private SubsystemCommunicationConfiguarations constructor
+	 */
+	private SubsystemCommunicationConfiguarations() {
+	}
+
+	/**
+	 * Get
+	 *
+	 * @param sourceSubsystemType the source subsystem type
+	 * @param targetSubsystemType the target subsystem type
+	 * @return
+	 */
+	public static SubsystemCommunicationInfo getSourceSubsystemCommunicationInfo(
+			SubsystemComponentType sourceSubsystemType, SubsystemComponentType targetSubsystemType) {
+
+		SubsystemCommunicationInfo communicationInfo = null;
+
+		switch (sourceSubsystemType) {
+		case SCHEDULER:
+			communicationInfo = new SubsystemCommunicationInfo(SCHEDULER_IP_ADDRESS,
+					SCHEDULER_PORT_MAPPING.get(targetSubsystemType));
+			break;
+
+		case FLOOR_SUBSYSTEM:
+			communicationInfo = new SubsystemCommunicationInfo(FLOOR_IP_ADDRESS,
+					FLOOR_PORT_MAPPING.get(targetSubsystemType));
+
+			break;
+
+		case ELEVATOR_SUBSYSTEM:
+			communicationInfo = new SubsystemCommunicationInfo(ELEVATOR_IP_ADDRESS,
+					ELEVATOR_PORT_MAPPING.get(targetSubsystemType));
+			break;
+		}
+
+		return communicationInfo;
+	}
+
+}

--- a/src/common/remote_procedure/SubsystemCommunicationInfo.java
+++ b/src/common/remote_procedure/SubsystemCommunicationInfo.java
@@ -4,29 +4,31 @@ package common.remote_procedure;
  * The class stores the communication information for a given subsystem.
  */
 public class SubsystemCommunicationInfo {
-	
+
 	/*
 	 * The ip address of the subsystem.
 	 */
-	private String ipAddress ="";
-	
+	private String ipAddress = "";
+
 	/*
 	 * THe port number of the subsystem.
 	 */
 	private int portNumber;
-	
+
 	/**
 	 * A SubsystemCommunicationInfo constructor.
-	 * @param ipAddress the ip address
+	 *
+	 * @param ipAddress  the ip address
 	 * @param portNumber the port number
 	 */
 	public SubsystemCommunicationInfo(String ipAddress, int portNumber) {
 		this.ipAddress = ipAddress;
 		this.portNumber = portNumber;
 	}
-	
+
 	/**
 	 * The method gets the ip address
+	 *
 	 * @return the ip address
 	 */
 	public String getIpAddress() {
@@ -35,12 +37,11 @@ public class SubsystemCommunicationInfo {
 
 	/**
 	 * THe method gets the port number
+	 *
 	 * @return the port number
 	 */
 	public int getPortNumber() {
 		return portNumber;
 	}
-	
-	
 
 }

--- a/src/common/remote_procedure/SubsystemCommunicationInfo.java
+++ b/src/common/remote_procedure/SubsystemCommunicationInfo.java
@@ -1,0 +1,46 @@
+package common.remote_procedure;
+
+/*
+ * The class stores the communication information for a given subsystem.
+ */
+public class SubsystemCommunicationInfo {
+	
+	/*
+	 * The ip address of the subsystem.
+	 */
+	private String ipAddress ="";
+	
+	/*
+	 * THe port number of the subsystem.
+	 */
+	private int portNumber;
+	
+	/**
+	 * A SubsystemCommunicationInfo constructor.
+	 * @param ipAddress the ip address
+	 * @param portNumber the port number
+	 */
+	public SubsystemCommunicationInfo(String ipAddress, int portNumber) {
+		this.ipAddress = ipAddress;
+		this.portNumber = portNumber;
+	}
+	
+	/**
+	 * The method gets the ip address
+	 * @return the ip address
+	 */
+	public String getIpAddress() {
+		return ipAddress;
+	}
+
+	/**
+	 * THe method gets the port number
+	 * @return the port number
+	 */
+	public int getPortNumber() {
+		return portNumber;
+	}
+	
+	
+
+}

--- a/src/common/remote_procedure/SubsystemCommunicationInfo.java
+++ b/src/common/remote_procedure/SubsystemCommunicationInfo.java
@@ -1,5 +1,7 @@
 package common.remote_procedure;
 
+import java.net.InetAddress;
+
 /*
  * The class stores the communication information for a given subsystem.
  */
@@ -23,6 +25,17 @@ public class SubsystemCommunicationInfo {
 	 */
 	public SubsystemCommunicationInfo(String ipAddress, int portNumber) {
 		this.ipAddress = ipAddress;
+		this.portNumber = portNumber;
+	}
+
+	/**
+	 * A SubsystemCommunicationInfo constructor.
+	 *
+	 * @param inetAddress the inet-address
+	 * @param portNumber  the port number
+	 */
+	public SubsystemCommunicationInfo(InetAddress inetAddress, int portNumber) {
+		this.ipAddress = inetAddress.getHostAddress();
 		this.portNumber = portNumber;
 	}
 

--- a/src/common/remote_procedure/SubsystemComponentType.java
+++ b/src/common/remote_procedure/SubsystemComponentType.java
@@ -1,0 +1,28 @@
+/**
+ *
+ */
+package common.remote_procedure;
+
+/**
+ * This class contains the different types of subsystems
+ *
+ * @author paulokenne
+ *
+ */
+public enum SubsystemComponentType {
+
+	/**
+	 * The scheduler
+	 */
+	SCHEDULER,
+
+	/**
+	 * The elevator subsystem
+	 */
+	ELEVATOR_SUBSYSTEM,
+
+	/**
+	 * The floor subsystem
+	 */
+	FLOOR_SUBSYSTEM,
+}

--- a/src/common/remote_procedure/SubystemCommunicationRPC.java
+++ b/src/common/remote_procedure/SubystemCommunicationRPC.java
@@ -1,0 +1,35 @@
+/**
+ *
+ */
+package common.remote_procedure;
+
+import java.net.DatagramSocket;
+
+/**
+ * This class enables communication between the subsystems using remote
+ * procedure calls.
+ *
+ * @author paulokenne, delight
+ *
+ */
+public class SubystemCommunicationRPC {
+
+	/**
+	 * The send and receive socket
+	 */
+	private DatagramSocket sendReceiveSocket;
+
+	/**
+	 * A SubystemCommunicationRPC constructor
+	 *
+	 * @param sendReceiveSocket the send and receive socket
+	 */
+	public SubystemCommunicationRPC(DatagramSocket sendReceiveSocket) {
+		this.sendReceiveSocket = sendReceiveSocket;
+	}
+
+	public Message sendAndReceiveData() {
+
+	}
+
+}

--- a/src/common/remote_procedure/SubystemCommunicationRPC.java
+++ b/src/common/remote_procedure/SubystemCommunicationRPC.java
@@ -5,6 +5,8 @@ package common.remote_procedure;
 
 import java.net.DatagramSocket;
 
+import common.messages.Message;
+
 /**
  * This class enables communication between the subsystems using remote
  * procedure calls.
@@ -29,7 +31,7 @@ public class SubystemCommunicationRPC {
 	}
 
 	public Message sendAndReceiveData() {
-
+		return null;
 	}
 
 }

--- a/src/common/remote_procedure/SubystemCommunicationRPC.java
+++ b/src/common/remote_procedure/SubystemCommunicationRPC.java
@@ -3,8 +3,17 @@
  */
 package common.remote_procedure;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.net.DatagramPacket;
 import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.util.Base64;
 
+import common.messages.CommunicationFailureMessage;
 import common.messages.Message;
 
 /**
@@ -17,21 +26,144 @@ import common.messages.Message;
 public class SubystemCommunicationRPC {
 
 	/**
+	 * The maximum buffer size
+	 */
+	public static final int MAX_BUFFER_SIZE = 1000;
+	/**
 	 * The send and receive socket
 	 */
 	private DatagramSocket sendReceiveSocket;
 
 	/**
+	 * The target subsystem communication info which includes the port and ip
+	 */
+	private SubsystemCommunicationInfo targetSubsystemInfo;
+
+	/**
 	 * A SubystemCommunicationRPC constructor
 	 *
-	 * @param sendReceiveSocket the send and receive socket
+	 * @param sendReceiveSocket   the send and receive socket
+	 * @param targetSubsystemInfo the target subsystem communication info
 	 */
-	public SubystemCommunicationRPC(DatagramSocket sendReceiveSocket) {
+	public SubystemCommunicationRPC(DatagramSocket sendReceiveSocket, SubsystemCommunicationInfo targetSubsystemInfo) {
 		this.sendReceiveSocket = sendReceiveSocket;
 	}
 
-	public Message sendAndReceiveData() {
-		return null;
+	/**
+	 * Sends a given request message and returns the response
+	 *
+	 * @param message the message to be sent
+	 * @return the response messages
+	 */
+	public Message sendRequestAndReceiveResponse(Message message) {
+		try {
+			sendMessage(message);
+			return receiveMessage();
+		} catch (Exception e) {
+			return new CommunicationFailureMessage();
+		}
 	}
 
+	/**
+	 * Send the given message
+	 *
+	 * @param message the message to be sent
+	 */
+	private void sendMessage(Message message) throws Exception {
+
+		byte[] messageBytes = getByteArrayFromMessage(message);
+
+		String targetSubsystemIpAddress = targetSubsystemInfo.getIpAddress();
+		int targetSubsystemPort = targetSubsystemInfo.getPortNumber();
+
+		try {
+
+			DatagramPacket sendPacket = new DatagramPacket(messageBytes, messageBytes.length,
+					InetAddress.getByName(targetSubsystemIpAddress), targetSubsystemPort);
+
+			sendReceiveSocket.send(sendPacket);
+		} catch (Exception e) {
+			System.out.print(e);
+		}
+	}
+
+	/**
+	 * Receive the response message.
+	 *
+	 * @return the response message
+	 */
+	private Message receiveMessage() throws Exception {
+
+		byte[] data = new byte[MAX_BUFFER_SIZE];
+		DatagramPacket receivePacket = new DatagramPacket(data, data.length);
+
+		try {
+			sendReceiveSocket.receive(receivePacket);
+
+			return getMessageFromPacket(receivePacket);
+		} catch (Exception excepetion) {
+			System.out.print(excepetion);
+			throw excepetion;
+		}
+	}
+
+	/**
+	 * Turn a given message into a byte array
+	 *
+	 * @return a byte array representation of the message
+	 */
+	private byte[] getByteArrayFromMessage(Message message) throws Exception {
+
+		try {
+			ByteArrayOutputStream byteOutputStream = new ByteArrayOutputStream();
+			ObjectOutputStream objectOutStream = new ObjectOutputStream(byteOutputStream);
+
+			objectOutStream.writeObject(message);
+			objectOutStream.flush();
+
+			return Base64.getEncoder().encode(byteOutputStream.toByteArray());
+		} catch (IOException e) {
+			System.out.println(e);
+			throw e;
+		}
+	}
+
+	/**
+	 * Return the message that is in the packet
+	 *
+	 * @return the received message
+	 */
+	private Message getMessageFromPacket(DatagramPacket receivePacket) throws Exception {
+
+		try {
+			byte[] receivedData = Base64.getDecoder().decode(getSentByteArray(receivePacket));
+
+			ByteArrayInputStream byteInputStream = new ByteArrayInputStream(receivedData);
+			ObjectInputStream objectInputStream = new ObjectInputStream(byteInputStream);
+
+			return (Message) objectInputStream.readObject();
+
+		} catch (IOException e) {
+			System.out.println(e);
+			throw new Exception("Cannot create byte array from message!");
+		}
+	}
+
+	/**
+	 * Given a packet, this function returns the actual data byte array that was
+	 * sent
+	 *
+	 * @param receivePacket the received packet
+	 * @return the sent data byte array
+	 */
+	private byte[] getSentByteArray(DatagramPacket receivePacket) {
+		byte[] sentData = new byte[receivePacket.getLength()];
+		byte[] receivedData = receivePacket.getData();
+
+		for (int i = 0; i < receivePacket.getLength(); i++) {
+			sentData[i] = receivedData[i];
+		}
+
+		return sentData;
+	}
 }

--- a/src/common/remote_procedure/SubystemCommunicationRPC.java
+++ b/src/common/remote_procedure/SubystemCommunicationRPC.java
@@ -11,6 +11,7 @@ import java.io.ObjectOutputStream;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
+import java.net.SocketException;
 import java.util.Base64;
 
 import common.messages.CommunicationFailureMessage;
@@ -42,12 +43,24 @@ public class SubystemCommunicationRPC {
 	/**
 	 * A SubystemCommunicationRPC constructor
 	 *
-	 * @param sendReceiveSocket   the send and receive socket
-	 * @param targetSubsystemInfo the target subsystem communication info
+	 * @param sourceSubsystemType the source subsystem type
+	 * @param targetSubsystemType the target subsystem type
 	 */
-	public SubystemCommunicationRPC(DatagramSocket sendReceiveSocket, SubsystemCommunicationInfo targetSubsystemInfo) {
-		this.sendReceiveSocket = sendReceiveSocket;
-		this.targetSubsystemInfo = targetSubsystemInfo;
+	public SubystemCommunicationRPC(SubsystemComponentType sourceSubsystemType,
+			SubsystemComponentType targetSubsystemType) {
+
+		try {
+			// Set up the source's send and receive socket
+			SubsystemCommunicationInfo sourceCommunicationInfo = SubsystemCommunicationConfiguarations
+					.getSourceSubsystemCommunicationInfo(sourceSubsystemType, targetSubsystemType);
+			this.sendReceiveSocket = new DatagramSocket(sourceCommunicationInfo.getPortNumber());
+
+			targetSubsystemInfo = SubsystemCommunicationConfiguarations
+					.getSourceSubsystemCommunicationInfo(targetSubsystemType, sourceSubsystemType);
+
+		} catch (SocketException e) {
+			System.out.println(e);
+		}
 	}
 
 	/**
@@ -70,7 +83,7 @@ public class SubystemCommunicationRPC {
 	 *
 	 * @param message the message to be sent
 	 */
-	private void sendMessage(Message message) throws Exception {
+	public void sendMessage(Message message) throws Exception {
 
 		byte[] messageBytes = getByteArrayFromMessage(message);
 
@@ -92,7 +105,7 @@ public class SubystemCommunicationRPC {
 	 *
 	 * @return the response message
 	 */
-	private Message receiveMessage() throws Exception {
+	public Message receiveMessage() throws Exception {
 
 		byte[] data = new byte[MAX_BUFFER_SIZE];
 		DatagramPacket receivePacket = new DatagramPacket(data, data.length);

--- a/src/common/remote_procedure/SubystemCommunicationRPC.java
+++ b/src/common/remote_procedure/SubystemCommunicationRPC.java
@@ -57,6 +57,7 @@ public class SubystemCommunicationRPC {
 	 */
 	public Message sendRequestAndReceiveResponse(Message message) {
 		try {
+			System.out.println(message);
 			sendMessage(message);
 			return receiveMessage();
 		} catch (Exception e) {

--- a/src/common/remote_procedure/SubystemCommunicationRPC.java
+++ b/src/common/remote_procedure/SubystemCommunicationRPC.java
@@ -47,6 +47,7 @@ public class SubystemCommunicationRPC {
 	 */
 	public SubystemCommunicationRPC(DatagramSocket sendReceiveSocket, SubsystemCommunicationInfo targetSubsystemInfo) {
 		this.sendReceiveSocket = sendReceiveSocket;
+		this.targetSubsystemInfo = targetSubsystemInfo;
 	}
 
 	/**
@@ -57,7 +58,6 @@ public class SubystemCommunicationRPC {
 	 */
 	public Message sendRequestAndReceiveResponse(Message message) {
 		try {
-			System.out.println(message);
 			sendMessage(message);
 			return receiveMessage();
 		} catch (Exception e) {
@@ -78,7 +78,6 @@ public class SubystemCommunicationRPC {
 		int targetSubsystemPort = targetSubsystemInfo.getPortNumber();
 
 		try {
-
 			DatagramPacket sendPacket = new DatagramPacket(messageBytes, messageBytes.length,
 					InetAddress.getByName(targetSubsystemIpAddress), targetSubsystemPort);
 

--- a/src/tests/common/SubystemCommunicationRPCTest.java
+++ b/src/tests/common/SubystemCommunicationRPCTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
-import java.net.InetAddress;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -13,7 +12,8 @@ import org.junit.jupiter.api.Test;
 
 import common.messages.Message;
 import common.messages.MessageType;
-import common.remote_procedure.SubsystemCommunicationInfo;
+import common.remote_procedure.SubsystemCommunicationConfiguarations;
+import common.remote_procedure.SubsystemComponentType;
 import common.remote_procedure.SubystemCommunicationRPC;
 
 /**
@@ -45,15 +45,10 @@ public class SubystemCommunicationRPCTest {
 	 */
 	@BeforeEach
 	void setUp() throws Exception {
-		String hostIpAddress = InetAddress.getLocalHost().getHostAddress();
-		int portNumber = 8999;
-
-		targetSubsystemSocket = new DatagramSocket(portNumber);
-		sourceSubsystemSendReceiveSocket = new DatagramSocket();
-
-		SubsystemCommunicationInfo targetSubsystemInfo = new SubsystemCommunicationInfo(hostIpAddress, portNumber);
-		this.subsystemCommunication = new SubystemCommunicationRPC(sourceSubsystemSendReceiveSocket,
-				targetSubsystemInfo);
+		this.subsystemCommunication = new SubystemCommunicationRPC(SubsystemComponentType.SCHEDULER,
+				SubsystemComponentType.ELEVATOR_SUBSYSTEM);
+		this.targetSubsystemSocket = new DatagramSocket(
+				SubsystemCommunicationConfiguarations.ELEVATOR_PORT_MAPPING.get(SubsystemComponentType.SCHEDULER));
 
 		/**
 		 * The thread simulates the SubystemCommunicationRPC response by sending the
@@ -85,7 +80,6 @@ public class SubystemCommunicationRPCTest {
 	@AfterEach
 	void closeSockets() throws Exception {
 		targetSubsystemSocket.close();
-		sourceSubsystemSendReceiveSocket.close();
 	}
 
 	/**
@@ -93,7 +87,7 @@ public class SubystemCommunicationRPCTest {
 	 * receive a response
 	 */
 	@Test
-	public void testRPCCommunication() {
+	public void testRPCCommunicationForsendingRequestAndReceivingResponses() {
 		Message testMessage = new Message(MessageType.TEST_REQUEST);
 		Message responseMessage = subsystemCommunication.sendRequestAndReceiveResponse(testMessage);
 		assertTrue(responseMessage.getMessageType() == MessageType.TEST_REQUEST);

--- a/src/tests/common/SubystemCommunicationRPCTest.java
+++ b/src/tests/common/SubystemCommunicationRPCTest.java
@@ -1,77 +1,101 @@
 package tests.common;
-import static org.junit.Assert.*;
+
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.net.DatagramPacket;
 import java.net.DatagramSocket;
 import java.net.InetAddress;
 
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import Scheduler.Scheduler;
 import common.messages.Message;
-import common.messages.MessageChannel;
 import common.messages.MessageType;
 import common.remote_procedure.SubsystemCommunicationInfo;
 import common.remote_procedure.SubystemCommunicationRPC;
+
 /**
- * This class tests the send and receive functionality of SubystemCommunicationRPC.
+ * This class tests the send and receive functionality of
+ * SubystemCommunicationRPC.
+ *
  * @author delightoluwayemi
  *
  */
 public class SubystemCommunicationRPCTest {
 
 	/**
-	 * Create a new SubystemCommunicationRPC object. 
+	 * Create a new SubystemCommunicationRPC object.
 	 */
 	private SubystemCommunicationRPC subsystemCommunication;
-	
-	
+
+	/**
+	 * The target subsystem socket
+	 */
+	DatagramSocket targetSubsystemSocket;
+
+	/**
+	 * The target subsystem socket
+	 */
+	DatagramSocket sourceSubsystemSendReceiveSocket;
+
 	/**
 	 * @throws java.lang.Exception
 	 */
 	@BeforeEach
 	void setUp() throws Exception {
-		DatagramSocket sendReceiveSocket = new DatagramSocket();
 		String hostIpAddress = InetAddress.getLocalHost().getHostAddress();
-		
-		int portNumber = 9999;
-		DatagramSocket targetSubsystemSocket = new DatagramSocket(portNumber);
-		
-		SubsystemCommunicationInfo targetSubsystemInfo = new SubsystemCommunicationInfo(hostIpAddress,portNumber);
-		this.subsystemCommunication = new SubystemCommunicationRPC(sendReceiveSocket, targetSubsystemInfo);
-		System.out.println(subsystemCommunication);
+		int portNumber = 8999;
 
-		
+		targetSubsystemSocket = new DatagramSocket(portNumber);
+		sourceSubsystemSendReceiveSocket = new DatagramSocket();
+
+		SubsystemCommunicationInfo targetSubsystemInfo = new SubsystemCommunicationInfo(hostIpAddress, portNumber);
+		this.subsystemCommunication = new SubystemCommunicationRPC(sourceSubsystemSendReceiveSocket,
+				targetSubsystemInfo);
+
 		/**
-		 * The thread simulates the SubystemCommunicationRPC response by sending the received message.
+		 * The thread simulates the SubystemCommunicationRPC response by sending the
+		 * received message.
 		 */
 		Thread subsystemSimulatorResponse = new Thread() {
-			
-			@Override 
-			public void run(){
+
+			@Override
+			public void run() {
 				byte[] data = new byte[SubystemCommunicationRPC.MAX_BUFFER_SIZE];
 				DatagramPacket receivePacket = new DatagramPacket(data, data.length);
 				try {
 					targetSubsystemSocket.receive(receivePacket);
 					targetSubsystemSocket.send(receivePacket);
+					targetSubsystemSocket.close();
 				} catch (IOException e) {
 					e.printStackTrace();
-				}	
+				}
 			}
 		};
 		subsystemSimulatorResponse.start();
 	}
-	
+
 	/**
-	 * This test case tests that the RPC communication can send a request and receive a response
+	 * Close sockets
+	 *
+	 * @throws Exception if errors occur
+	 */
+	@AfterEach
+	void closeSockets() throws Exception {
+		targetSubsystemSocket.close();
+		sourceSubsystemSendReceiveSocket.close();
+	}
+
+	/**
+	 * This test case tests that the RPC communication can send a request and
+	 * receive a response
 	 */
 	@Test
 	public void testRPCCommunication() {
 		Message testMessage = new Message(MessageType.TEST_REQUEST);
-		System.out.println(subsystemCommunication);
-		Message responseMessage= subsystemCommunication.sendRequestAndReceiveResponse(testMessage);
+		Message responseMessage = subsystemCommunication.sendRequestAndReceiveResponse(testMessage);
 		assertTrue(responseMessage.getMessageType() == MessageType.TEST_REQUEST);
 	}
 

--- a/src/tests/common/SubystemCommunicationRPCTest.java
+++ b/src/tests/common/SubystemCommunicationRPCTest.java
@@ -1,0 +1,78 @@
+package tests.common;
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+
+import Scheduler.Scheduler;
+import common.messages.Message;
+import common.messages.MessageChannel;
+import common.messages.MessageType;
+import common.remote_procedure.SubsystemCommunicationInfo;
+import common.remote_procedure.SubystemCommunicationRPC;
+/**
+ * This class tests the send and receive functionality of SubystemCommunicationRPC.
+ * @author delightoluwayemi
+ *
+ */
+public class SubystemCommunicationRPCTest {
+
+	/**
+	 * Create a new SubystemCommunicationRPC object. 
+	 */
+	private SubystemCommunicationRPC subsystemCommunication;
+	
+	
+	/**
+	 * @throws java.lang.Exception
+	 */
+	@BeforeEach
+	void setUp() throws Exception {
+		DatagramSocket sendReceiveSocket = new DatagramSocket();
+		String hostIpAddress = InetAddress.getLocalHost().getHostAddress();
+		
+		int portNumber = 9999;
+		DatagramSocket targetSubsystemSocket = new DatagramSocket(portNumber);
+		
+		SubsystemCommunicationInfo targetSubsystemInfo = new SubsystemCommunicationInfo(hostIpAddress,portNumber);
+		this.subsystemCommunication = new SubystemCommunicationRPC(sendReceiveSocket, targetSubsystemInfo);
+		System.out.println(subsystemCommunication);
+
+		
+		/**
+		 * The thread simulates the SubystemCommunicationRPC response by sending the received message.
+		 */
+		Thread subsystemSimulatorResponse = new Thread() {
+			
+			@Override 
+			public void run(){
+				byte[] data = new byte[SubystemCommunicationRPC.MAX_BUFFER_SIZE];
+				DatagramPacket receivePacket = new DatagramPacket(data, data.length);
+				try {
+					targetSubsystemSocket.receive(receivePacket);
+					targetSubsystemSocket.send(receivePacket);
+				} catch (IOException e) {
+					e.printStackTrace();
+				}	
+			}
+		};
+		subsystemSimulatorResponse.start();
+	}
+	
+	/**
+	 * This test case tests that the RPC communication can send a request and receive a response
+	 */
+	@Test
+	public void testRPCCommunication() {
+		Message testMessage = new Message(MessageType.TEST_REQUEST);
+		System.out.println(subsystemCommunication);
+		Message responseMessage= subsystemCommunication.sendRequestAndReceiveResponse(testMessage);
+		assertTrue(responseMessage.getMessageType() == MessageType.TEST_REQUEST);
+	}
+
+}


### PR DESCRIPTION
Delight and I introduced the SubsystemCommunicationRPC. 

This class ensures that we can send message requests, receive message request, and **send & receive** messages.

The class also takes care of the configuration of the subsystem's sockets and ip so no one needs to worry.

The class has two parameters: the source subsystem component type and the target subsystem component type. With those two parameters, everything else will be set up .

A SubsystemCommunicationRPC instance provides 3 public functions:
-  sendRequestAndReceiveResponse(Message)
- sendMessage(Message)
- receiveMessage()

For each subsystem, the constructors will no longer have message channel parameters. 

Instead of 3 global MessageChannel variables, we would have 2 SubsystemCommunicationRPC instances. 

Here is a floor subsystem example of the instantiation of the variables:

```
FloorSubsystem(){
  SubsystemCommunicationRPC elevatorCommunication = new SubsystemCommunicationRPC( SubsystemComponentType.FLOOR_SUBSYSTEM, SubsystemComponentType.ELEVATOR_SUBSYSTEM);

  SubsystemCommunicationRPC schedulerCommunication = new SubsystemCommunicationRPC( SubsystemComponentType.FLOOR_SUBSYSTEM, SubsystemComponentType.SCHEDULER);
}
```

I think we should all incorporate the SubsystemCommunicationRPC in our respective subsystems. It will minimize integration with the sockets and ip. It also ensures that everyone performs RPC with one class; if that class works, everyone's communication works.

--------------------------------------------------------
Test Cases

I have added a test case to verify that it works


