### PR TITLE
Add smexy logger

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <classpath>
 	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="logs"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER">
 		<attributes>
 			<attribute name="module" value="true"/>

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /bin/
 .DS_Store
+/logs/

--- a/src/ElevatorSubsystem/ElevatorFloorMessageWorkQueue.java
+++ b/src/ElevatorSubsystem/ElevatorFloorMessageWorkQueue.java
@@ -1,11 +1,12 @@
 package ElevatorSubsystem;
 
 import java.util.Map;
+import java.util.logging.Logger;
 
+import common.LoggerWrapper;
 import common.messages.Message;
 import common.messages.elevator.ElevatorFloorArrivalMessage;
 import common.messages.elevator.ElevatorStatusMessage;
-import common.messages.elevator.ElevatorTransportRequest;
 import common.remote_procedure.SubsystemCommunicationRPC;
 import common.work_management.MessageWorkQueue;
 
@@ -16,6 +17,7 @@ import common.work_management.MessageWorkQueue;
  */
 public class ElevatorFloorMessageWorkQueue extends MessageWorkQueue {
 	private SubsystemCommunicationRPC schedulerSubsystemCommunication;
+	private Logger logger = LoggerWrapper.getLogger();
 
 	private Map<Integer, ElevatorCar> elevators;
 
@@ -39,7 +41,7 @@ public class ElevatorFloorMessageWorkQueue extends MessageWorkQueue {
 					ElevatorCar car = elevators.get(carId); 
 					car.setFloorNumber(floorNumber);
 					
-					System.out.println("(ELEVATOR) Elevator " + carId + " has reached floor: " + floorNumber);
+					logger.info("(ELEVATOR) Elevator " + carId + " has reached floor: " + floorNumber);
 					ElevatorStatusMessage arrivalStatus = car.createStatusMessage();
 				
 					schedulerSubsystemCommunication.sendMessage(arrivalStatus);
@@ -50,7 +52,7 @@ public class ElevatorFloorMessageWorkQueue extends MessageWorkQueue {
 					break;
 					
 				default:
-					System.out.println("(ELEVATOR) received improper message from FLOOR of type: " + message.getMessageType());
+					logger.fine("(ELEVATOR) received improper message from FLOOR of type: " + message.getMessageType());
 					break;
 			}
 		} catch (Exception e) {

--- a/src/ElevatorSubsystem/ElevatorSchedulerMessageWorkQueue.java
+++ b/src/ElevatorSubsystem/ElevatorSchedulerMessageWorkQueue.java
@@ -1,7 +1,9 @@
 package ElevatorSubsystem;
 
 import java.util.Map;
+import java.util.logging.Logger;
 
+import common.LoggerWrapper;
 import common.messages.Message;
 import common.messages.elevator.ElevatorFloorSignalRequestMessage;
 import common.messages.elevator.ElevatorLeavingFloorMessage;
@@ -19,6 +21,7 @@ import common.work_management.MessageWorkQueue;
 public class ElevatorSchedulerMessageWorkQueue extends MessageWorkQueue{
 	private SubsystemCommunicationRPC schedulerSubsystemCommunication;
 	private SubsystemCommunicationRPC floorSubsystemCommunication;
+	private Logger logger = LoggerWrapper.getLogger();
 	
 	private Map<Integer, ElevatorCar> elevators;
 	
@@ -70,28 +73,28 @@ public class ElevatorSchedulerMessageWorkQueue extends MessageWorkQueue{
 			switch(command.getCommand()) {
 				case STOP:
 					if(!car.getDoor().isOpen()) {
-						System.out.println("Elevator stopping\n");
+						logger.fine("(ELEVATOR) Elevator " + car.getId() + " stopping");
 						car.getMotor().turnOff();
 					}else {
 						car.setErrorState(new Exception("Attempted to stop while doors open"));
 					}
 					break;
 				case CLOSE_DOORS:
-					System.out.println("Elevator door closing\n");
+					logger.fine("(ELEVATOR) Elevator " + car.getId() + " door closing");
 					car.getDoor().closeDoor();
 					break;
 				case OPEN_DOORS:
 					if(!car.getMotor().getIsRunning()) {
-						System.out.println("Elevator door opening\n");
+						logger.fine("(ELEVATOR) Elevator " + car.getId() + " door opening");
 						car.getDoor().openDoor();
 					}else {
 						car.setErrorState(new Exception("Attempted to open doors while motor running"));
 					}
 					break;
 				case MOVE_UP:
-					System.out.println("Elevator door closing\n");
+					logger.fine("(ELEVATOR) Elevator " + car.getId() +  " door closing");
 					car.getDoor().closeDoor();
-					System.out.println("Elevator moving up\n");
+					logger.fine("(ELEVATOR) Elevator " + car.getId() + " moving up");
 					car.getMotor().goUp();
 					
 					leavingMessage = new ElevatorLeavingFloorMessage(car.getId(), carFloorNumber);
@@ -101,9 +104,9 @@ public class ElevatorSchedulerMessageWorkQueue extends MessageWorkQueue{
 					floorSubsystemCommunication.sendMessage(comingMessage);
 					break;
 				case MOVE_DOWN:
-					System.out.println("Elevator door closing\n");
+					logger.fine("(ELEVATOR) Elevator " + car.getId() + " door closing");
 					car.getDoor().closeDoor();
-					System.out.println("Elevator moving down\n");
+					logger.fine("(ELEVATOR) Elevator " + car.getId() + " moving down");
 					car.getMotor().goDown();
 					
 					leavingMessage = new ElevatorLeavingFloorMessage(car.getId(), carFloorNumber);

--- a/src/FloorSubsystem/FloorElevatorComponents.java
+++ b/src/FloorSubsystem/FloorElevatorComponents.java
@@ -3,8 +3,11 @@
  */
 package FloorSubsystem;
 
+import java.util.logging.Logger;
+
 import ElevatorSubsystem.ElevatorMotor;
 import common.Direction;
+import common.LoggerWrapper;
 import common.messages.elevator.ElevatorFloorArrivalMessage;
 import common.remote_procedure.SubsystemCommunicationRPC;
 
@@ -16,6 +19,8 @@ import common.remote_procedure.SubsystemCommunicationRPC;
  *
  */
 public class FloorElevatorComponents {
+
+	private Logger logger = LoggerWrapper.getLogger();
 
 	/**
 	 * The elevator id
@@ -164,15 +169,15 @@ public class FloorElevatorComponents {
 			@Override
 			public void run() {
 				try {
-					System.out.println("\n(FLOOR_SUBSYSTEM) Elevator (id = " + elevatorId + ") sensor for floor "
-							+ floorNumber + " is waiting for " + totalTimeInMilliSeconds + "ms.\n");
+					logger.fine("(FLOOR_SUBSYSTEM) Elevator " + elevatorId + " sensor for floor "
+							+ floorNumber + " is waiting for " + totalTimeInMilliSeconds + "ms.");
 					Thread.sleep(totalTimeInMilliSeconds);
 				} catch (InterruptedException e) {
 					System.out.println(e);
 				}
 
-				System.out.println("\n(FLOOR_SUBSYSTEM) Elevator(id = " + elevatorId + ") has reached the floor "
-						+ floorNumber + "\n");
+				logger.fine("(FLOOR_SUBSYSTEM) Elevator " + elevatorId + " has reached the floor "
+						+ floorNumber);
 
 				// For now, we will assume that the motor's elevatorDirection is where the
 				// elevator plans to go

--- a/src/Scheduler/SchedulerElevatorWorkHandler.java
+++ b/src/Scheduler/SchedulerElevatorWorkHandler.java
@@ -3,6 +3,9 @@
  */
 package Scheduler;
 
+import java.util.logging.Logger;
+
+import common.LoggerWrapper;
 import common.messages.ElevatorJobMessage;
 import common.messages.Message;
 import common.messages.elevator.ElevatorStatusMessage;
@@ -14,6 +17,7 @@ import common.remote_procedure.SubsystemCommunicationRPC;
  *
  */
 public class SchedulerElevatorWorkHandler extends SchedulerWorkHandler {
+	private Logger logger = LoggerWrapper.getLogger();
 
 	/**
 	 * The SchedulerFloorMessageWorkQueue constructor
@@ -46,16 +50,15 @@ public class SchedulerElevatorWorkHandler extends SchedulerWorkHandler {
 				// should proceed like normal.
 				elevatorJobManagements[elevatorId].setErrorState(elevatorStatusMessage.getErrorState());
 				if (elevatorStatusMessage.getErrorState() != null) {
-					System.out.println(
-							"(SCHEDULER) Elevator(id = " + elevatorId + ") has an error. Shutting down elevator...");
+					logger.severe("(SCHEDULER) Elevator " + elevatorId + " has an error. Shutting down elevator...");
 					elevatorJobManagements[elevatorId].setReadyForJob(false);
 				} else {
 					elevatorJobManagements[elevatorId].setReadyForJob(true);
 				}
 
-				System.out.println("(SCHEDULER) Received Elevator status: [EF: "
-						+ elevatorStatusMessage.getFloorNumber() + ", ED: " + elevatorStatusMessage.getDirection()
-						+ ", EID: " + elevatorId + ", ES:" + elevatorStatusMessage.getErrorState() + " ]\n");
+				logger.fine("(SCHEDULER) Received Elevator status: [ID: " + elevatorId + ", F: "
+						+ elevatorStatusMessage.getFloorNumber() + ", D: " + elevatorStatusMessage.getDirection()
+						+ ", ErrorState: " + elevatorStatusMessage.getErrorState() + " ]");
 
 				if (elevatorJobManagements[elevatorId].isReadyForJob()
 						&& elevatorJobManagements[elevatorId].hasJobs()) {
@@ -78,14 +81,14 @@ public class SchedulerElevatorWorkHandler extends SchedulerWorkHandler {
 
 				elevatorJobManagements[elevatorId].addJob((ElevatorJobMessage) message);
 
-				System.out.println("\n(SCHEDULER) Assigning DROP_OFF_PASSENGER Job (Direction = "
+				logger.info("(SCHEDULER) Assigning DROP_OFF_PASSENGER Job (Direction = "
 						+ dropPassengerRequest.getDirection() + " @ floor = "
-						+ dropPassengerRequest.getDestinationFloor() + ") to Elevator (id = "
-						+ elevatorJobManagements[elevatorId].getElevatorId() + ")");
+						+ dropPassengerRequest.getDestinationFloor() + ") to Elevator "
+						+ elevatorJobManagements[elevatorId].getElevatorId());
 
-				System.out.println("(SCHEDULER) Elevator Management Status: [EF: "
-						+ elevatorJobManagements[elevatorId].getCurrentFloorNumber() + ", ED: "
-						+ elevatorJobManagements[elevatorId].getElevatorDirection() + ", EID: " + elevatorId + " ]\n");
+				logger.fine("(SCHEDULER) Elevator Management Status: [ID: " + elevatorId +", F: "
+						+ elevatorJobManagements[elevatorId].getCurrentFloorNumber() + ", D: "
+						+ elevatorJobManagements[elevatorId].getElevatorDirection() + "]");
 
 				executeNextElevatorCommand(elevatorJobManagements[elevatorId]);
 			}

--- a/src/Scheduler/SchedulerFloorWorkHandler.java
+++ b/src/Scheduler/SchedulerFloorWorkHandler.java
@@ -3,6 +3,9 @@
  */
 package Scheduler;
 
+import java.util.logging.Logger;
+
+import common.LoggerWrapper;
 import common.messages.ElevatorJobMessage;
 import common.messages.Message;
 import common.remote_procedure.SubsystemCommunicationRPC;
@@ -15,6 +18,7 @@ import common.remote_procedure.SubsystemCommunicationRPC;
  *
  */
 public class SchedulerFloorWorkHandler extends SchedulerWorkHandler {
+	private Logger logger = LoggerWrapper.getLogger();
 
 	/**
 	 * The SchedulerFloorMessageWorkQueue constructor
@@ -36,7 +40,7 @@ public class SchedulerFloorWorkHandler extends SchedulerWorkHandler {
 
 		case ELEVATOR_PICK_UP_PASSENGER_REQUEST:
 			ElevatorJobMessage job = (ElevatorJobMessage) message;
-			System.out.println("\nScheduler received floor request: go to floor " + job.getDestinationFloor() + "\n");
+			logger.info("(SCHEDULER) Received floor request: go to floor " + job.getDestinationFloor());
 			handleElevatorPickUpPassengerRequest(job);
 			break;
 
@@ -82,7 +86,7 @@ public class SchedulerFloorWorkHandler extends SchedulerWorkHandler {
 			// If we do not have an in-service elevator, we will discard the request and
 			// provide a log
 			if (assumedBestElevatorJobManagement == null) {
-				System.out.println(
+				logger.fine(
 						"No Elevator is available...Scheduler is ingoring the received Passenger-Pick-Up REQUEST @ Floor "
 								+ elevatorFloorJob.getDestinationFloor());
 				return;
@@ -140,9 +144,9 @@ public class SchedulerFloorWorkHandler extends SchedulerWorkHandler {
 
 			assumedBestElevatorJobManagement.addJob(elevatorFloorJob);
 
-			System.out.println("\n(SCHEDULER) Assigning PICK_UP_PASSENGER Job (Direction = "
+			logger.fine("(SCHEDULER) Assigning PICK_UP_PASSENGER Job (Direction = "
 					+ elevatorFloorJob.getDirection() + " @ floor = " + elevatorFloorJob.getDestinationFloor()
-					+ ") to Elevator (id = " + assumedBestElevatorJobManagement.getElevatorId() + ")\n");
+					+ ") to Elevator " + assumedBestElevatorJobManagement.getElevatorId());
 
 			// If the elevator is not currently running a job, we will update the elevator's
 			// direction and issue the appropriate elevator commands

--- a/src/Scheduler/SchedulerWorkHandler.java
+++ b/src/Scheduler/SchedulerWorkHandler.java
@@ -110,7 +110,7 @@ public abstract class SchedulerWorkHandler extends MessageWorkQueue {
 		try {
 			// Move down if we above the target floor
 			if (elevatorJobManagement.getCurrentFloorNumber() > nearestTargetFloor) {
-				logger.fine("(SCHEDULER) Sending a DOWN commmand to Elevator " + elevatorId);
+				logger.fine("(SCHEDULER) Sending a DOWN command to Elevator " + elevatorId);
 
 				schedulerElevatorCommunication
 						.sendMessage(new SchedulerElevatorCommand(ElevatorCommand.MOVE_DOWN, elevatorId));
@@ -118,7 +118,7 @@ public abstract class SchedulerWorkHandler extends MessageWorkQueue {
 			}
 			// Move up if we below the target floor
 			else if (elevatorJobManagement.getCurrentFloorNumber() < nearestTargetFloor) {
-				logger.fine("(SCHEDULER) Sending an UP commmand to Elevator " + elevatorId);
+				logger.fine("(SCHEDULER) Sending an UP command to Elevator " + elevatorId);
 				schedulerElevatorCommunication
 						.sendMessage(new SchedulerElevatorCommand(ElevatorCommand.MOVE_UP, elevatorId));
 

--- a/src/Scheduler/SchedulerWorkHandler.java
+++ b/src/Scheduler/SchedulerWorkHandler.java
@@ -4,8 +4,10 @@
 package Scheduler;
 
 import java.util.ArrayList;
+import java.util.logging.Logger;
 
 import common.Direction;
+import common.LoggerWrapper;
 import common.messages.ElevatorJobMessage;
 import common.messages.Message;
 import common.messages.MessageType;
@@ -20,10 +22,11 @@ import common.work_management.MessageWorkQueue;
 /**
  * * This class represents the scheduler's work queue handler.
  *
- * @author paulokenne
+ * @author paulokenne, ryanfife
  *
  */
 public abstract class SchedulerWorkHandler extends MessageWorkQueue {
+	private Logger logger = LoggerWrapper.getLogger();
 
 	/**
 	 * The job management for each elevator
@@ -89,7 +92,7 @@ public abstract class SchedulerWorkHandler extends MessageWorkQueue {
 			handleElevatorBehavior(elevatorJobManagement, nearestTargetFloor);
 		} else {
 			// This should never happen...If it ever occurs, we need to know
-			System.out.println("Invalid Nearest Target Floor! Some thing is wrong...");
+			logger.severe("Invalid Nearest Target Floor! Some thing is wrong...");
 		}
 
 	}
@@ -107,7 +110,7 @@ public abstract class SchedulerWorkHandler extends MessageWorkQueue {
 		try {
 			// Move down if we above the target floor
 			if (elevatorJobManagement.getCurrentFloorNumber() > nearestTargetFloor) {
-				System.out.println("\n(SCHEDULER) Sending a DOWN commmand to Elevator(id = " + elevatorId + ") ");
+				logger.fine("(SCHEDULER) Sending a DOWN commmand to Elevator " + elevatorId);
 
 				schedulerElevatorCommunication
 						.sendMessage(new SchedulerElevatorCommand(ElevatorCommand.MOVE_DOWN, elevatorId));
@@ -115,7 +118,7 @@ public abstract class SchedulerWorkHandler extends MessageWorkQueue {
 			}
 			// Move up if we below the target floor
 			else if (elevatorJobManagement.getCurrentFloorNumber() < nearestTargetFloor) {
-				System.out.println("\n(SCHEDULER) Sending an UP commmand to Elevator(id = " + elevatorId + ") ");
+				logger.fine("(SCHEDULER) Sending an UP commmand to Elevator " + elevatorId);
 				schedulerElevatorCommunication
 						.sendMessage(new SchedulerElevatorCommand(ElevatorCommand.MOVE_UP, elevatorId));
 
@@ -144,12 +147,12 @@ public abstract class SchedulerWorkHandler extends MessageWorkQueue {
 					}
 				}
 
-				String addressedJobMessage = "(SCHEDULER) Elevator (id = " + elevatorId + ") has addressed: ";
+				String addressedJobMessage = "(SCHEDULER) Elevator " + elevatorId + " has addressed: ";
 				for (ElevatorJobMessage job : jobsAtTargetFloor) {
 					addressedJobMessage += "(" + job.getMessageType() + " job - " + job.getDirection() + " @ floor = "
-							+ job.getDestinationFloor() + "),";
+							+ job.getDestinationFloor() + ")";
 				}
-				System.out.println("\n" + addressedJobMessage + "\n");
+				logger.fine(addressedJobMessage);
 
 				// Stop the elevator and open the doors
 				schedulerElevatorCommunication
@@ -181,7 +184,7 @@ public abstract class SchedulerWorkHandler extends MessageWorkQueue {
 			}
 
 		} catch (Exception e) {
-			System.out.println("Error occurred in handleElevatorBehavior: " + e);
+			logger.severe("Error occurred in handleElevatorBehavior: " + e);
 		}
 	}
 

--- a/src/common/LoggerWrapper.java
+++ b/src/common/LoggerWrapper.java
@@ -1,0 +1,95 @@
+package common;
+import java.io.OutputStream;
+import java.util.Date;
+import java.util.logging.ConsoleHandler;
+import java.util.logging.FileHandler;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+import java.util.logging.SimpleFormatter;
+import java.util.logging.StreamHandler;
+
+/**
+ * Logger wrapper for app.
+ * 
+ * Logger levels breakdown (subject to change)
+ * 
+ * severe (highest priority) = critical system errors
+ * info = high level app functionality
+ * fine (lowest priority) = non essential behaviour messages, used for debug purposes
+ * 
+ * @author Ryan Fife
+ */
+
+public class LoggerWrapper {
+	private static String OUTPUT_FILENAME = "./logs/log.txt";
+	private static Logger logger = null;
+	
+	/**
+	 * Instantiate the global logger singleton
+	 * 
+	 * @return logger
+	 */
+	private static Logger instantiateLogger() {
+		Logger logger = Logger.getLogger("global");
+		
+		try {
+	        // setup the proper log format
+	        SimpleFormatter format = new SimpleFormatter() {
+	            private static final String format = "[%1$tF %1$tT] [%2$-7s] %3$s %n";
+
+	            @Override
+	            public synchronized String format(LogRecord lr) {
+	                return String.format(format,
+	                        new Date(lr.getMillis()),
+	                        lr.getLevel().getLocalizedName(),
+	                        lr.getMessage()
+	                );
+	            }
+	        };
+	        
+	        // console handler outputs to sys.err by default, extend so we can output to sys.out instead
+	        class StdoutConsoleHandler extends ConsoleHandler {
+	        	  protected void setOutputStream(OutputStream out) throws SecurityException {
+	        	    super.setOutputStream(System.out);
+	        	  }
+        	}
+	        
+	        // setup both output handler
+	        StdoutConsoleHandler consoleHandler = new StdoutConsoleHandler();
+			FileHandler fileHandler = new FileHandler(OUTPUT_FILENAME);
+	        consoleHandler.setFormatter(format);
+	        fileHandler.setFormatter(format);
+	         
+	        // console will output only high level info about system state
+	        consoleHandler.setLevel(Level.INFO);
+	        // file output will contain all level info, for debugging purposes
+	        fileHandler.setLevel(Level.ALL);
+	        
+	        // set logger level
+	        logger.setLevel(Level.ALL);
+	        // attach handlers to loggers
+	        logger.addHandler(fileHandler);
+	        logger.addHandler(consoleHandler);
+			// use only defined handlers
+			logger.setUseParentHandlers(false);
+		} catch(Exception e) {
+			e.printStackTrace();
+		}
+		
+		return logger;
+	}
+	
+	/**
+	 * Gets the logger singleton, instantiating on first access
+	 * 
+	 * @return logger
+	 */
+	public static Logger getLogger() {
+		// only want to use one logger instantiation app-wide
+		if(logger == null) {
+			logger = instantiateLogger();
+		}
+		return logger;
+	}
+}


### PR DESCRIPTION
This PR adds a global logger for use around our application. The logger is a singleton that uses a simple configuration to output to two streams. First stream is the console containing high level app behaviour logs. Second stream is the file containing low level app behaviour logs (useful for debugging). Additionally I cleaned up a lot of the logging style around the app so that we stay consistent. Most style alignments include:

1. adding correct subsystem prefixes to messages
2. aligning the presentation of ids in messages "Elevator (id = 1)" changed to "Elevator 1"
3. Removing newline characters

**Instantiation**
To instantiate logger simply add "Logger logger = LoggerWrapper.getLogger()" in class attributes.

**Use**
After instantiating simply use logger.info(msg) for a high level log, logger.severe(msg) for an error log, or logger.fine(msg) for non critical debugging logs. Other levels can be used as well see https://docs.oracle.com/javase/7/docs/api/java/util/logging/Level.html for all log levels. Although we should only need to use the three aforementioned levels.

**Screenshot**
Both console and file output is displayed below. Output for SystemExecutor.main() iter 3.
![example logs](https://user-images.githubusercontent.com/52329291/159099717-64946a0c-8032-4ba1-bdef-2760eadfbeba.PNG)
