### PR TITLE
Iter 5: door-stuck-open elevator fault handling update

### DIFF
--- a/src/ElevatorSubsystem/ElevatorCar.java
+++ b/src/ElevatorSubsystem/ElevatorCar.java
@@ -47,6 +47,11 @@ public class ElevatorCar {
 	private ElevatorAutoFixing autoFixing = ElevatorAutoFixing.AUTO_FIXING_SUCCESS;
 
 	/**
+	 * A flag indicating that the elevator care is resolving an error
+	 */
+	private boolean isResolvingError = false;
+
+	/**
 	 * The elevator car
 	 *
 	 * @param id    the car id
@@ -68,7 +73,20 @@ public class ElevatorCar {
 	 */
 	public ElevatorStatusMessage createStatusMessage() {
 		ElevatorStatusMessage status = new ElevatorStatusMessage(id, this.getMotor().getDirection(), floorNumber,
-				errorState);
+				errorState, isResolvingError);
+
+		return status;
+	}
+
+	/**
+	 * Creates a ElevatorStatusMessage message containing all relevant status info
+	 * for this elevator.
+	 *
+	 * @return status response message
+	 */
+	public ElevatorStatusMessage createCommandNonIssuingStatusMessage() {
+		ElevatorStatusMessage status = new ElevatorStatusMessage(id, this.getMotor().getDirection(), floorNumber,
+				errorState, isResolvingError, false);
 
 		return status;
 	}
@@ -167,4 +185,23 @@ public class ElevatorCar {
 	public void setFloorNumber(int floorNumber) {
 		this.floorNumber = floorNumber;
 	}
+
+	/**
+	 * Return a flag indicating whether the car is currently resolving an error
+	 *
+	 * @return the isResolvingError
+	 */
+	public boolean isResolvingError() {
+		return isResolvingError;
+	}
+
+	/**
+	 * Set the resolving error Flag
+	 *
+	 * @param isResolvingError the isResolvingError to set
+	 */
+	public void setResolvingError(boolean isResolvingError) {
+		this.isResolvingError = isResolvingError;
+	}
+
 }

--- a/src/FloorSubsystem/FloorSubsystem.java
+++ b/src/FloorSubsystem/FloorSubsystem.java
@@ -158,11 +158,8 @@ public class FloorSubsystem {
 				for (SimulationFloorInputData floorInputData : floorDataCollection) {
 
 					ElevatorFloorRequest elevatorFloorRequest = new ElevatorFloorRequest(
-							floorInputData.getCurrentFloor(),
-							floorInputData.getFloorDirectionButton(),
-							floorInputData.getInputDataId(),
-							floorInputData.getFault(),
-							floorInputData.getFaultFloor());
+							floorInputData.getCurrentFloor(), floorInputData.getFloorDirectionButton(),
+							floorInputData.getInputDataId(), floorInputData.getFault(), floorInputData.getFaultFloor());
 
 					// Updating the floor properties(User interacting with the floor button)
 					int floorId = floorInputData.getCurrentFloor();

--- a/src/Scheduler/ElevatorJobManagement.java
+++ b/src/Scheduler/ElevatorJobManagement.java
@@ -70,6 +70,15 @@ public class ElevatorJobManagement {
 	}
 
 	/**
+	 * Return the elevator jobs
+	 *
+	 * @return the elevatorJobs
+	 */
+	public Set<ElevatorJobMessage> getElevatorJobs() {
+		return elevatorJobs;
+	}
+
+	/**
 	 * Return a flag indicating whether the elevator is in an error state
 	 *
 	 * @return true if elevator is in an error state; otherwise, return false
@@ -138,13 +147,32 @@ public class ElevatorJobManagement {
 	 * @param errorState the error state to set
 	 */
 	public void setErrorState(Exception errorState) {
-		if (errorState != null) {
-			logger.fine("(SCHEDULER) Elevator " + elevatorId
-					+ " has an error. No longer assigning jobs to this elevator...");
-			this.readyForJob = false;
-		} else {
-			this.readyForJob = true;
+		setErrorState(errorState, false);
+	}
+
+	/**
+	 * Set the error state
+	 *
+	 * @param errorState       the error state to set
+	 * @param isResolvingError a flag indicating if the elevator is resolving an
+	 *                         error
+	 */
+	public void setErrorState(Exception errorState, boolean isResolvingError) {
+
+		if (isResolvingError == false) {
+			if (errorState != null) {
+				logger.fine("(SCHEDULER) Elevator " + elevatorId
+						+ " has an error. No longer assigning jobs to this elevator...");
+				this.readyForJob = false;
+			} else {
+				this.readyForJob = true;
+			}
 		}
+
+		// If the elevator is resolving an error, we will leave the elevator in-service
+		// flag (readyForJob) as is.
+
+		// Set the error state
 		this.errorState = errorState;
 	}
 

--- a/src/Scheduler/SchedulerElevatorWorkHandler.java
+++ b/src/Scheduler/SchedulerElevatorWorkHandler.java
@@ -48,12 +48,29 @@ public class SchedulerElevatorWorkHandler extends SchedulerWorkHandler {
 				// For now, if the elevator goes into an error state we will hold its job
 				// requests. Once manual actions have be taken on the elevator, the elevator
 				// should proceed like normal.
-				elevatorJobManagements[elevatorId].setErrorState(elevatorStatusMessage.getErrorState());
+				elevatorJobManagements[elevatorId].setErrorState(elevatorStatusMessage.getErrorState(),
+						elevatorStatusMessage.isResolvingError());
 
 				logger.fine("(SCHEDULER) Received Elevator status: [ID: " + elevatorId + ", F: "
 						+ elevatorStatusMessage.getFloorNumber() + ", D: " + elevatorStatusMessage.getDirection()
 						+ ", ErrorState: " + elevatorStatusMessage.getErrorState() + " ]");
 
+				// If the elevator shuts down, notify the floor subsystem that we have addressed
+				// the jobs in the elevators
+				if (!elevatorJobManagements[elevatorId].isReadyForJob()) {
+
+					// For each job, notify the floor subsystem
+					elevatorJobManagements[elevatorId].getElevatorJobs().forEach(elevator -> {
+						// schedulerFloorCommunication.sendMessage(JOB_COMPLETED_MESSAGE)
+					});
+				}
+
+				// If the scheduler should not give any commands, do not proceed any further
+				if (!elevatorStatusMessage.shouldIssueNextCommand()) {
+					return;
+				}
+
+				// If the elevator is ready for job and has jobs, issue the next command
 				if (elevatorJobManagements[elevatorId].isReadyForJob()
 						&& elevatorJobManagements[elevatorId].hasJobs()) {
 					executeNextElevatorCommand(elevatorJobManagements[elevatorId]);
@@ -79,7 +96,7 @@ public class SchedulerElevatorWorkHandler extends SchedulerWorkHandler {
 						+ dropPassengerRequest.getDestinationFloor() + " to Elevator "
 						+ elevatorJobManagements[elevatorId].getElevatorId());
 
-				logger.fine("(SCHEDULER) Elevator Management Status: [ID: " + elevatorId +", F: "
+				logger.fine("(SCHEDULER) Elevator Management Status: [ID: " + elevatorId + ", F: "
 						+ elevatorJobManagements[elevatorId].getCurrentFloorNumber() + ", D: "
 						+ elevatorJobManagements[elevatorId].getElevatorDirection() + "]");
 

--- a/src/common/exceptions/ElevatorStateException.java
+++ b/src/common/exceptions/ElevatorStateException.java
@@ -2,23 +2,48 @@ package common.exceptions;
 
 import FloorSubsystem.FloorInputFault;
 
+/**
+ * An elevator state exception
+ *
+ * @author ryanfife, paulokenne
+ *
+ */
 public class ElevatorStateException extends Exception {
 
+	/**
+	 * The floor input fault
+	 */
 	private FloorInputFault fault;
+
+	/**
+	 * The floor number
+	 */
 	private int floorNumber = -1;
-	//
-	
+
+	/**
+	 * A ElevatorStateException constructor
+	 *
+	 * @param fault   the fault
+	 * @param message the message
+	 */
 	public ElevatorStateException(FloorInputFault fault, String message) {
 		super(message);
 		this.fault = fault;
 	}
-	
+
+	/**
+	 * A ElevatorStateException constructor
+	 *
+	 * @param fault       the fault
+	 * @param floorNumber the floor number
+	 * @param message     the message
+	 */
 	public ElevatorStateException(FloorInputFault fault, int floorNumber, String message) {
 		super(message);
 		this.fault = fault;
 		this.floorNumber = floorNumber;
 	}
-	
+
 	/**
 	 * @return the fault
 	 */
@@ -33,7 +58,9 @@ public class ElevatorStateException extends Exception {
 		return floorNumber;
 	}
 
+	@Override
 	public String toString() {
-		return ElevatorStateException.class.toString() +" : [" + fault +" near Floor " + floorNumber + "]: " + this.getMessage();
+		return ElevatorStateException.class.toString() + " : [" + fault + " near Floor " + floorNumber + "]: "
+				+ this.getMessage();
 	}
 }

--- a/src/common/messages/elevator/ElevatorStatusMessage.java
+++ b/src/common/messages/elevator/ElevatorStatusMessage.java
@@ -15,13 +15,54 @@ import common.messages.MessageType;
  */
 
 public class ElevatorStatusMessage extends Message {
+
+	/**
+	 * The elevator id
+	 */
 	private int elevatorId;
+
+	/**
+	 * The flood number
+	 */
 	private int floorNumber;
+
+	/**
+	 * The direction
+	 */
 	private Direction direction;
+
+	/**
+	 * A time stamp
+	 */
 	private String timestamp;
+
+	/**
+	 * The exception
+	 */
 	private Exception errorState;
-	
-	public ElevatorStatusMessage(int elevatorId, Direction direction, int floorNumber, Exception errorState) {
+
+	/**
+	 * A flag indicating that the elevator is resolving an error
+	 */
+	private boolean isResolvingError;
+
+	/**
+	 * A flag that indicates that the scheduler should issue the next command
+	 */
+	private boolean issueNextCommand = true;
+
+	/**
+	 * A ElevatorStatusMessage constructor
+	 *
+	 * @param elevatorId       the elevator id
+	 * @param direction        the direction
+	 * @param floorNumber      the floor number
+	 * @param errorState       the error state
+	 * @param isResolvingError a flag indicating that the elevator is resolving an
+	 *                         error
+	 */
+	public ElevatorStatusMessage(int elevatorId, Direction direction, int floorNumber, Exception errorState,
+			boolean isResolvingError) {
 		super(MessageType.ELEVATOR_STATUS_MESSAGE);
 		this.timestamp = DateFormat.DATE_FORMAT.format(new Date());
 
@@ -29,6 +70,30 @@ public class ElevatorStatusMessage extends Message {
 		this.direction = direction;
 		this.floorNumber = floorNumber;
 		this.errorState = errorState;
+		this.isResolvingError = isResolvingError;
+	}
+
+	/**
+	 * A ElevatorStatusMessage constructor
+	 *
+	 * @param elevatorId       the elevator id
+	 * @param direction        the direction
+	 * @param floorNumber      the floor number
+	 * @param errorState       the error state
+	 * @param isResolvingError a flag indicating that the elevator is resolving an
+	 *                         error
+	 */
+	public ElevatorStatusMessage(int elevatorId, Direction direction, int floorNumber, Exception errorState,
+			boolean isResolvingError, boolean issueNextCommand) {
+		super(MessageType.ELEVATOR_STATUS_MESSAGE);
+		this.timestamp = DateFormat.DATE_FORMAT.format(new Date());
+
+		this.elevatorId = elevatorId;
+		this.direction = direction;
+		this.floorNumber = floorNumber;
+		this.errorState = errorState;
+		this.isResolvingError = isResolvingError;
+		this.issueNextCommand = issueNextCommand;
 	}
 
 	/**
@@ -65,4 +130,21 @@ public class ElevatorStatusMessage extends Message {
 	public Exception getErrorState() {
 		return errorState;
 	}
+
+	/**
+	 * @return the isResolvingError
+	 */
+	public boolean isResolvingError() {
+		return isResolvingError;
+	}
+
+	/**
+	 * Return a flag indicating whether the scheduler should issue the next commant
+	 *
+	 * @return the issueNextCommand
+	 */
+	public boolean shouldIssueNextCommand() {
+		return issueNextCommand;
+	}
+
 }

--- a/src/tests/Scheduler/SchedulerElevatorWorkHandlerTest.java
+++ b/src/tests/Scheduler/SchedulerElevatorWorkHandlerTest.java
@@ -128,7 +128,7 @@ public class SchedulerElevatorWorkHandlerTest {
 		// The elevator is at floor 1 and is sending a status message.
 		currentFloorNumber = 1;
 		ElevatorStatusMessage elevatorStatusMessage = new ElevatorStatusMessage(elevatorId, Direction.DOWN,
-				currentFloorNumber, null);
+				currentFloorNumber, null, false);
 
 		// Add elevator message and let the scheduler work
 		schedulerElevatorWorkHandler.enqueueMessage(elevatorStatusMessage);
@@ -148,7 +148,7 @@ public class SchedulerElevatorWorkHandlerTest {
 
 		// The elevator is at floor 0 and is sending a status message.
 		currentFloorNumber = 0;
-		elevatorStatusMessage = new ElevatorStatusMessage(elevatorId, Direction.DOWN, currentFloorNumber, null);
+		elevatorStatusMessage = new ElevatorStatusMessage(elevatorId, Direction.DOWN, currentFloorNumber, null, false);
 
 		simulateElevatorSubsystemWaitingForCommand();
 		simulateElevatorSubsystemWaitingForCommand();


### PR DESCRIPTION
The elevator door-stuck-open fault uses the elevator status message as a key point. 

As result, the GUI team can place event generators at the elevator status message handling.